### PR TITLE
workflow: use self-hosted runner to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: ${{ inputs.environment }}
     steps:
       - uses: actions/download-artifact@v4

--- a/renovate.json
+++ b/renovate.json
@@ -14,18 +14,24 @@
   "postUpdateOptions": [
     "pnpmDedupe"
   ],
-  "ignoreDeps": [
-    "eslint"
-  ],
   "packageRules": [
     {
-      "description": "Automerge non-major updates",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
+      "groupName": "all dependencies",
+      "groupSlug": "all",
+      "description": "Automerge updates",
+      "matchPackageNames": [
+        "*"
       ],
-      "matchCurrentVersion": "!/^0/",
+      "matchUpdateTypes": [
+        "digest",
+        "patch",
+        "minor",
+        "major"
+      ],
       "automerge": true
     }
+  ],
+  "ignoreDeps": [
+    "eslint"
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档更新**
	- 部署工作流配置已更新，执行环境从GitHub托管的运行器更改为自托管运行器。
  
- **新特性**
	- `renovate.json`配置文件进行了多项修改，包括更新依赖忽略列表和包规则，以支持更灵活的自动合并策略。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->